### PR TITLE
ArriveBy Functionality 

### DIFF
--- a/src/routers/GetRouteRouter.js
+++ b/src/routers/GetRouteRouter.js
@@ -21,70 +21,156 @@ class GetRouteRouter extends AppDevRouter {
 
   async content (req: Request) {
     console.log(req.url);
-    const leaveBy = parseInt(req.query.leave_by);
-    const dayStartTime = TimeUtils.unixTimeToDayTime(leaveBy);
-    const serviceDate = TimeUtils.unixTimeToGTFSDate(leaveBy);
-    const {buses, stopsToRoutes} = await GTFS.buses(serviceDate);
+    let leaveBy = parseInt(req.query.leave_by);
+    let arriveBy = parseInt(req.query.arrive_by);
+    console.log(isNaN(arriveBy));
 
-    // Start coordinate
-    const startCoords = TCATUtils.coordStringToCoords(req.query.start_coords);
-    const start = new Stop(
-      TCATConstants.START_WALKING,
-      new Location(startCoords.latitude, startCoords.longitude)
-    );
+    if (isNaN(arriveBy)) {
+      const dayStartTime = TimeUtils.unixTimeToDayTime(j);
+      const serviceDate = TimeUtils.unixTimeToGTFSDate(j);
+      const {buses, stopsToRoutes} = await GTFS.buses(serviceDate);
 
-    // End coordinate
-    const endCoords = TCATUtils.coordStringToCoords(req.query.end_coords);
-    const end = new Stop(
-      TCATConstants.END_WALKING,
-      new Location(endCoords.latitude, endCoords.longitude)
-    );
-
-    // Start / end stops
-    const footpathMatrix = await BasedRaptorUtils.footpathMatrix(start, end);
-
-    // Extrapolate out by intervals
-    let results: Array<RaptorResponseElement> = [];
-    for (let i = 0; i <= 30 * 60; i += 5 * 60) {
-      const basedRaptor = new BasedRaptor(
-        buses,
-        start,
-        end,
-        stopsToRoutes,
-        footpathMatrix,
-        dayStartTime + i,
-        GTFS.stops
+      // Start coordinate
+      const startCoords = TCATUtils.coordStringToCoords(req.query.start_coords);
+      const start = new Stop(
+        TCATConstants.START_WALKING,
+        new Location(startCoords.latitude, startCoords.longitude)
       );
-      results = results.concat(basedRaptor.run());
+
+      // End coordinate
+      const endCoords = TCATUtils.coordStringToCoords(req.query.end_coords);
+      const end = new Stop(
+        TCATConstants.END_WALKING,
+        new Location(endCoords.latitude, endCoords.longitude)
+      );
+
+      // Start / end stops
+      const footpathMatrix = await BasedRaptorUtils.footpathMatrix(start, end);
+
+      // Extrapolate out by intervals
+      let results: Array<RaptorResponseElement> = [];
+      for (let i = 0; i <= 30 * 60; i += 5 * 60) {
+        const basedRaptor = new BasedRaptor(
+          buses,
+          start,
+          end,
+          stopsToRoutes,
+          footpathMatrix,
+          dayStartTime + i,
+          GTFS.stops
+        );
+        results = results.concat(basedRaptor.run());
+      }
+
+      // Sort
+      results.sort((a: RaptorResponseElement, b: RaptorResponseElement) => {
+        if (a.arrivalTime < b.arrivalTime) {
+          return -1;
+        } else if (a.arrivalTime > b.arrivalTime) {
+          return 1;
+        }
+        return 0;
+      });
+
+      // Filter - ensure that no routes are returned with the same stop-wise
+      // progression (set of names --> unique identifier for that)
+      let routeSet = new Set();
+      results = results.filter((r: RaptorResponseElement): boolean => {
+        let stopProgression = r.path.map(e => e.start.name);
+        let stringified = JSON.stringify(stopProgression);
+        if (routeSet.has(stringified)) return false;
+        routeSet.add(stringified);
+        return true;
+      });
+
+      // Run Raptor
+      return {
+        results: results.slice(0, 4), // top 4
+        baseTime: j - dayStartTime
+      };
     }
 
-    // Sort
-    results.sort((a: RaptorResponseElement, b: RaptorResponseElement) => {
-      if (a.arrivalTime < b.arrivalTime) {
-        return -1;
-      } else if (a.arrivalTime > b.arrivalTime) {
-        return 1;
+    if (arriveBy < leaveBy) {
+      return {error: "arriveBy less than leaveBy"};
+    }
+
+    let prevRaptor = null;
+    console.time("t0");
+    for (let j = arriveBy; j >= leaveBy; j--) {
+
+      const dayStartTime = TimeUtils.unixTimeToDayTime(j);
+      const serviceDate = TimeUtils.unixTimeToGTFSDate(j);
+      const {buses, stopsToRoutes} = await GTFS.buses(serviceDate);
+
+      // Start coordinate
+      const startCoords = TCATUtils.coordStringToCoords(req.query.start_coords);
+      const start = new Stop(
+        TCATConstants.START_WALKING,
+        new Location(startCoords.latitude, startCoords.longitude)
+      );
+
+      // End coordinate
+      const endCoords = TCATUtils.coordStringToCoords(req.query.end_coords);
+      const end = new Stop(
+        TCATConstants.END_WALKING,
+        new Location(endCoords.latitude, endCoords.longitude)
+      );
+
+      // Start / end stops
+      const footpathMatrix = await BasedRaptorUtils.footpathMatrix(start, end);
+
+      // Extrapolate out by intervals
+      let results: Array<RaptorResponseElement> = [];
+      for (let i = 0; i <= 30 * 60; i += 5 * 60) {
+        const basedRaptor = new BasedRaptor(
+          buses,
+          start,
+          end,
+          stopsToRoutes,
+          footpathMatrix,
+          dayStartTime + i,
+          GTFS.stops
+        );
+        results = results.concat(basedRaptor.run());
       }
-      return 0;
-    });
 
-    // Filter - ensure that no routes are returned with the same stop-wise
-    // progression (set of names --> unique identifier for that)
-    let routeSet = new Set();
-    results = results.filter((r: RaptorResponseElement): boolean => {
-      let stopProgression = r.path.map(e => e.start.name);
-      let stringified = JSON.stringify(stopProgression);
-      if (routeSet.has(stringified)) return false;
-      routeSet.add(stringified);
-      return true;
-    });
+      // Sort
+      results.sort((a: RaptorResponseElement, b: RaptorResponseElement) => {
+        if (a.arrivalTime < b.arrivalTime) {
+          return -1;
+        } else if (a.arrivalTime > b.arrivalTime) {
+          return 1;
+        }
+        return 0;
+      });
 
-    // Run Raptor
-    return {
-      results: results.slice(0, 4), // top 4
-      baseTime: parseInt(req.query.leave_by) - dayStartTime
-    };
+      // Filter - ensure that no routes are returned with the same stop-wise
+      // progression (set of names --> unique identifier for that)
+      let routeSet = new Set();
+      results = results.filter((r: RaptorResponseElement): boolean => {
+        let stopProgression = r.path.map(e => e.start.name);
+        let stringified = JSON.stringify(stopProgression);
+        if (routeSet.has(stringified)) return false;
+        routeSet.add(stringified);
+        return true;
+      });
+
+      // Run Raptor
+      let retVal = {
+        results: results.slice(0, 4), // top 4
+        baseTime: j - dayStartTime
+      };
+
+      if (Math.round(retVal.results[0].arrivalTime+retVal.baseTime-0.5) <= arriveBy){
+        console.log("break");
+        return retVal;
+      }
+      j -= (60*20);
+    }
+    console.timeEnd("t0");
+    return prevRaptor;
   }
+
 }
 
 export default new GetRouteRouter().router;

--- a/src/routers/GetRouteRouter.js
+++ b/src/routers/GetRouteRouter.js
@@ -26,8 +26,8 @@ class GetRouteRouter extends AppDevRouter {
     console.log(isNaN(arriveBy));
 
     if (isNaN(arriveBy)) {
-      const dayStartTime = TimeUtils.unixTimeToDayTime(j);
-      const serviceDate = TimeUtils.unixTimeToGTFSDate(j);
+      const dayStartTime = TimeUtils.unixTimeToDayTime(leaveBy);
+      const serviceDate = TimeUtils.unixTimeToGTFSDate(leaveBy);
       const {buses, stopsToRoutes} = await GTFS.buses(serviceDate);
 
       // Start coordinate
@@ -86,7 +86,7 @@ class GetRouteRouter extends AppDevRouter {
       // Run Raptor
       return {
         results: results.slice(0, 4), // top 4
-        baseTime: j - dayStartTime
+        baseTime: leaveBy - dayStartTime
       };
     }
 
@@ -162,7 +162,6 @@ class GetRouteRouter extends AppDevRouter {
       };
 
       if (Math.round(retVal.results[0].arrivalTime+retVal.baseTime-0.5) <= arriveBy){
-        console.log("break");
         return retVal;
       }
       j -= (60*20);


### PR DESCRIPTION
Rough Implementation of arrive_by functionality, works by starting at the arrival time and looping backwards, running Raptor until on 20 minute decrements until a path that is as close to the arrival time as possible is available.

Arrive by is activated on the presence of the ```arrive_by``` param in the request, and includes the starting time as ```leave_by```

@shivvo 
@Jma353 
@mattbarker016 