### PR TITLE
Fixes(?) destination walking direction bug

### DIFF
--- a/src/RouteUtils.js
+++ b/src/RouteUtils.js
@@ -69,7 +69,7 @@ function condense(route: Object, startCoords: Object, endCoords: Object) {
         route.directions.shift();
     }
     if(canLastDirectionBeRemoved){
-        route.directions.pop();
+        //route.directions.pop();
     }
 
     for (let index = 0; index < route.directions.length; index++) {


### PR DESCRIPTION
I think we need to reconsider the criteria for throwing out the last route. Commenting out this line makes sure the final walking direction is always included (try Gates Hall -> Baker Flagpole)