### PR TITLE
Removed dispose function from lru-cache constructor

### DIFF
--- a/src/routers/PlacesAutocompleteRouter.js
+++ b/src/routers/PlacesAutocompleteRouter.js
@@ -6,7 +6,6 @@ import LRU from 'lru-cache';
 
 const options = { 
     max: 10000,
-    dispose: function (key, n) { n.close() },
     maxAge: 1000 * 60 * 60 * 24 * 5,
 };
 const cache = LRU(options);


### PR DESCRIPTION
The example code for the `lru-cache` had a `dispose` function that's called every time a key is removed, but it was causing an error because the key had no `close` function. 

Verified that this was the error by setting cache size to 1 and `max-age` to 5 seconds, made sure that it repro-ed with these changes, and verified that it does not repro after removing this line.